### PR TITLE
Fix duping items

### DIFF
--- a/RPFramework.Altis/Functions/modules/BasicMedical/fn_basicMedicalUnconscious.sqf
+++ b/RPFramework.Altis/Functions/modules/BasicMedical/fn_basicMedicalUnconscious.sqf
@@ -58,6 +58,7 @@ player enableSimulation true;
 player allowDamage true;
 
 if (!(_unit getVariable ["unconscious",  false])) then {
+	_deadLoadout = [0, _unit, []]call ClientModules_fnc_basicMedicalLoadout;
 	[1, player, _deadLoadout]call ClientModules_fnc_basicMedicalLoadout;
 	
 	player setPos (getPos _unit);


### PR DESCRIPTION
Fixed duping the items by taking items off of a dead body. When medic would pick the dead dude up he would still have his items, even those that were taken. Previous variable assignement:
```sqf
_deadLoadout = [0, _unit, []]call ClientModules_fnc_basicMedicalLoadout;
```
was left as a fallback.